### PR TITLE
Add support for PostgresSQL to store state

### DIFF
--- a/christmasbot/constants/globals.py
+++ b/christmasbot/constants/globals.py
@@ -1,10 +1,22 @@
 from enum import IntEnum
 
+from sqlalchemy.engine.url import URL
+
 DISCORD_CLIENT_ID = '773308497538056222'
 DISCORD_TOKEN = ':)notthistime'
 
 DEFAULT_DESPAWN_TIME_SECONDS = 10
 DEFAULT_SPAWN_RATE_PERCENT = 100
+
+DB_CONFIG = URL(
+  drivername='postgres+psycopg2',
+  username='zoo',
+  password='wee',
+  host='mama',
+  port=5432,
+  database='christmasbot'
+)
+
 
 class ChristmasColor(IntEnum):
   RED = 0xBB2528

--- a/christmasbot/daos/__init__.py
+++ b/christmasbot/daos/__init__.py
@@ -1,5 +1,5 @@
 from daos.abstract_dao import AbstractDao
-from daos.memory_dao import MemoryDao
+from daos.db_dao import DbDao
 
 dao = None
 
@@ -7,5 +7,5 @@ dao = None
 def get_dao() -> AbstractDao:
   global dao
   if dao is None:
-    dao = MemoryDao()
+    dao = DbDao()
   return dao

--- a/christmasbot/daos/db_dao.py
+++ b/christmasbot/daos/db_dao.py
@@ -1,0 +1,237 @@
+from operator import and_
+import random
+
+from sqlalchemy.exc import InvalidRequestError
+from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.expression import func
+
+from daos.abstract_dao import AbstractDao
+from dtos.player import PlayerDto
+from dtos.server_config import ServerConfigDto
+from helpers.db import get_session, init_engine, servers_table, players_table, creatures_table, items_table
+
+
+class DbDao(AbstractDao):
+  def __init__(self):
+    init_engine()
+    
+
+  def create_server_entry_if_nonexistent(self, session: Session, server_id: int) -> ServerConfigDto:
+    server = session.query(servers_table).filter(servers_table.c.id == server_id).first()
+    if server is None:
+      # no server entry exists
+      server = ServerConfigDto(server_id)
+      session.add(server)
+    return server
+
+
+  # Create new player entry
+  # Precondition: server entry exists
+  def create_player_entry_if_nonexistent(self, session: Session, server_id: int, player_id: int) -> PlayerDto:
+    player = session.query(players_table).filter(
+      players_table.c.server_id == server_id,
+      players_table.c.player_id == player_id
+    ).first()
+    if player is None:
+      # no player entry exists
+      player = PlayerDto(server_id, player_id)
+      session.add(player)
+    return player
+
+  # Admin Config
+
+  async def enable_channel(self, server_id, channel_id):
+    session = get_session()
+    server = self.create_server_entry_if_nonexistent(session, server_id)
+    if channel_id not in server.enabled_channels:
+      server.enabled_channels.append(channel_id)
+      update_stmt = servers_table.update().where(servers_table.c.id == server_id).values(
+        enabled_channels=server.enabled_channels
+      )
+      session.execute(update_stmt)
+      session.commit()
+      return channel_id
+    else:
+      return None
+
+  async def disable_channel(self, server_id, channel_id):
+    session = get_session()
+    server = self.create_server_entry_if_nonexistent(session, server_id)
+    if channel_id in server.enabled_channels:
+      server.enabled_channels.remove(channel_id)
+      update_stmt = servers_table.update().where(servers_table.c.id == server_id).values(
+        enabled_channels=server.enabled_channels
+      )
+      session.execute(update_stmt)
+      session.commit()
+      return channel_id
+    else:
+      return None
+   
+   
+  async def change_despawn_time(self, server_id: int, new_despawn_time: int):
+    session = get_session()
+    server = self.create_server_entry_if_nonexistent(session, server_id)
+    if new_despawn_time < 0:
+      return None
+    else:
+      update_stmt = servers_table.update().where(servers_table.c.id == server_id).values(
+        despawn_time=new_despawn_time
+      )
+      session.execute(update_stmt)
+      session.commit()
+      return new_despawn_time
+
+
+  async def change_spawn_rate(self, server_id: int, new_spawn_rate: int):
+    session = get_session()
+    server = self.create_server_entry_if_nonexistent(session, server_id)
+    if new_spawn_rate < 0 or new_spawn_rate > 100:
+      return None
+    else:
+      update_stmt = servers_table.update().where(servers_table.c.id == server_id).values(
+        spawn_rate_percent=new_spawn_rate
+      )
+      session.execute(update_stmt)
+      session.commit()
+      return new_spawn_rate
+
+
+  # User Interactions
+
+  async def get_leaderboard(self, server_id: int, num_results: int, page: int):
+    """ Gets a list of players for server sorted by score
+    TODO add sorting by most recent acquired item time
+
+    Parameters:
+    - server_id (int): the discord ID of the server
+    - num_results (int): the number of results to get
+    - page (int): the page of results
+
+    Returns sorted list of players if successful and None if num_results <= 0 or page <= 0.
+    """
+    pass
+
+
+  async def get_player(self, server_id: int, player_id: int) -> PlayerDto:
+    session = get_session()
+    self.create_server_entry_if_nonexistent(session, server_id)
+    player = self.create_player_entry_if_nonexistent(session, server_id, player_id)
+    try:
+      # in case a new player is added but not committed yet
+      session.commit()
+    except InvalidRequestError:
+      # in case no new player is added, do nothing
+      pass
+    return player
+
+
+  async def get_server(self, server_id: int) -> ServerConfigDto:
+    session = get_session()
+    server = self.create_server_entry_if_nonexistent(session, server_id)
+    try:
+      # in case a new server is added but not committed yet
+      session.commit()
+    except InvalidRequestError:
+      # in case no new server is added, do nothing
+      pass
+    return server
+
+
+  # Spawn/Item Interactions
+
+  async def add_item_to_player(self, server_id: int, player_id: int, item_id: str):
+    session = get_session()
+    self.create_server_entry_if_nonexistent(session, server_id)
+    player = self.create_player_entry_if_nonexistent(session, server_id, player_id)
+    if item_id not in player.inventory:
+      player.inventory.append(item_id)
+      update_stmt = players_table.update().where(and_(
+        players_table.c.server_id == server_id,
+        players_table.c.player_id == player_id
+      )).values(
+        inventory=player.inventory,
+        score=player.score + 1
+      )
+      session.execute(update_stmt)
+      # A transaction is guaranteed because of the update statement, no needd
+      # to account for exceptions
+      session.commit()
+      return item_id
+    else:
+      # we don't need to commit anything here because if a player already has an
+      # item, then it cannot be just created and thus there's nothing to commit
+      return None
+
+
+  async def replace_player_item_with_coal(self, server_id: int, player_id: int):
+    session = get_session()
+    self.create_server_entry_if_nonexistent(session, server_id)
+    player = self.create_player_entry_if_nonexistent(session, server_id, player_id)
+    if len(player.inventory) > 0:
+      # player's inventory is not empty, replace an item
+      # TODO make this based on rarity
+      inventory_size = len(player.inventory)
+      index_to_remove = random.randrange(inventory_size)
+      removed_item = player.inventory.pop(index_to_remove)
+      update_stmt = players_table.update().where(
+        players_table.c.server_id == server_id
+      ).where(
+        players_table.c.player_id == player_id
+      ).values(
+        inventory=player.inventory,
+        coal_count=player.coal_count + 1,
+        score=player.score - 1
+      )
+      session.execute(update_stmt)
+      session.commit()
+      return removed_item
+    else:
+      # player's inventory is empty
+      # there's a chance that player was just created so we need to commit
+      try:
+        # in case a new server is added but not committed yet
+        session.commit()
+      except InvalidRequestError:
+        # in case no new server is added, do nothing
+        pass
+      finally:
+        return None
+
+
+  # Bot specific DAO calls
+
+  async def get_creature(self, creature_id: str):
+    session = get_session()
+    creature = session.query(creatures_table).filter(creatures_table.c.id == creature_id).first()
+    if creature is None:
+      raise Exception('Creature {} does not exist!'.format(creature_id))
+    else:
+      return creature
+
+
+  async def get_random_creature(self):
+    session = get_session()
+    creature = session.query(creatures_table).order_by(func.random()).first()
+    if creature is None:
+      raise Exception('No creatures exist to choose from!')
+    return creature
+
+    
+
+  async def get_item(self, item_id: str):
+    session = get_session()
+    item = session.query(items_table).filter(items_table.c.id == item_id).first()
+    if item is None:
+      raise Exception('Creature {} does not exist!'.format(item_id))
+    else:
+      return item
+
+  async def get_items(self, item_ids: list[str]):
+    session = get_session()
+    items = session.query(items_table).filter(items_table.c.id.in_(item_ids)).all()
+    if len(items) != len(item_ids):
+      raise Exception('An item within {} does not exist!'.format(str(item_ids)))
+    else:
+      return items
+  

--- a/christmasbot/helpers/db.py
+++ b/christmasbot/helpers/db.py
@@ -1,0 +1,64 @@
+from sqlalchemy import Table, Column, Integer, ARRAY, Text, MetaData
+from sqlalchemy.engine import create_engine
+from sqlalchemy.engine.base import Engine
+from sqlalchemy.orm import mapper, sessionmaker
+from sqlalchemy.orm.session import Session
+from sqlalchemy.sql.schema import ForeignKey
+
+from constants.globals import DB_CONFIG
+from dtos.creature import CreatureDto
+from dtos.item import ItemDto
+from dtos.player import PlayerDto
+from dtos.server_config import ServerConfigDto
+
+
+engine = None
+session_maker = None
+
+meta = MetaData(schema='beta')
+
+servers_table = Table('servers', meta, 
+  Column('id', Integer, primary_key=True),
+  Column('enabled_channels', ARRAY(Integer)),
+  Column('items', ARRAY(Text)),
+  Column('despawn_time', Integer),
+  Column('spawn_rate_percent', Integer)
+)
+
+players_table = Table('players', meta,
+  Column('server_id', Integer, ForeignKey('servers.id'), primary_key=True),
+  Column('player_id', Integer, primary_key=True),
+  Column('inventory', ARRAY(Text)),
+  Column('coal_count', Integer),
+  Column('score', Integer)
+)
+
+creatures_table = Table('creatures', meta,
+  Column('id', Text, primary_key=True),
+  Column('display_name', Text),
+  Column('img_url', Text),
+  Column('status', Text),
+  Column('pronoun', Text),
+  Column('items', ARRAY(Text))
+)
+
+items_table = Table('items', meta,
+  Column('id', Text, primary_key=True),
+  Column('display_name', Text),
+  Column('img_url', Text),
+  Column('rarity', Integer)
+)
+
+def init_engine():
+  global engine, session_maker
+  if engine is None:
+    engine = create_engine(DB_CONFIG)
+    session_maker = sessionmaker(bind=engine)
+    meta.bind = engine
+    mapper(ServerConfigDto, servers_table)
+    mapper(PlayerDto, players_table),
+    mapper(CreatureDto, creatures_table)
+    mapper(ItemDto, items_table)
+
+def get_session() -> Session:
+  return session_maker()

--- a/poetry.lock
+++ b/poetry.lock
@@ -86,6 +86,26 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
+name = "sqlalchemy"
+version = "1.3.20"
+description = "Database Abstraction Library"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+mssql = ["pyodbc"]
+mssql_pymssql = ["pymssql"]
+mssql_pyodbc = ["pyodbc"]
+mysql = ["mysqlclient"]
+oracle = ["cx-oracle"]
+postgresql = ["psycopg2"]
+postgresql_pg8000 = ["pg8000"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql"]
+
+[[package]]
 name = "yarl"
 version = "1.5.1"
 description = "Yet another URL library"
@@ -100,7 +120,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e9140c028b4c881a4bb97ece10f62808378e2d34de1aa9967699b95c3be02225"
+content-hash = "5aa5aa60d550268b34690a79f52daa244c196104f3c8c12f91759203c57ae2ba"
 
 [metadata.files]
 aiohttp = [
@@ -173,6 +193,46 @@ psycopg2 = [
     {file = "psycopg2-2.8.6-cp39-cp39-win32.whl", hash = "sha256:2c93d4d16933fea5bbacbe1aaf8fa8c1348740b2e50b3735d1b0bf8154cbf0f3"},
     {file = "psycopg2-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:d5062ae50b222da28253059880a871dc87e099c25cb68acf613d9d227413d6f7"},
     {file = "psycopg2-2.8.6.tar.gz", hash = "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"},
+]
+sqlalchemy = [
+    {file = "SQLAlchemy-1.3.20-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:bad73f9888d30f9e1d57ac8829f8a12091bdee4949b91db279569774a866a18e"},
+    {file = "SQLAlchemy-1.3.20-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:e32e3455db14602b6117f0f422f46bc297a3853ae2c322ecd1e2c4c04daf6ed5"},
+    {file = "SQLAlchemy-1.3.20-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:5cdfe54c1e37279dc70d92815464b77cd8ee30725adc9350f06074f91dbfeed2"},
+    {file = "SQLAlchemy-1.3.20-cp27-cp27m-win32.whl", hash = "sha256:2e9bd5b23bba8ae8ce4219c9333974ff5e103c857d9ff0e4b73dc4cb244c7d86"},
+    {file = "SQLAlchemy-1.3.20-cp27-cp27m-win_amd64.whl", hash = "sha256:5d92c18458a4aa27497a986038d5d797b5279268a2de303cd00910658e8d149c"},
+    {file = "SQLAlchemy-1.3.20-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:53fd857c6c8ffc0aa6a5a3a2619f6a74247e42ec9e46b836a8ffa4abe7aab327"},
+    {file = "SQLAlchemy-1.3.20-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:0a92745bb1ebbcb3985ed7bda379b94627f0edbc6c82e9e4bac4fb5647ae609a"},
+    {file = "SQLAlchemy-1.3.20-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:b6f036ecc017ec2e2cc2a40615b41850dc7aaaea6a932628c0afc73ab98ba3fb"},
+    {file = "SQLAlchemy-1.3.20-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3aa6d45e149a16aa1f0c46816397e12313d5e37f22205c26e06975e150ffcf2a"},
+    {file = "SQLAlchemy-1.3.20-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:ed53209b5f0f383acb49a927179fa51a6e2259878e164273ebc6815f3a752465"},
+    {file = "SQLAlchemy-1.3.20-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:d3b709d64b5cf064972b3763b47139e4a0dc4ae28a36437757f7663f67b99710"},
+    {file = "SQLAlchemy-1.3.20-cp35-cp35m-win32.whl", hash = "sha256:950f0e17ffba7a7ceb0dd056567bc5ade22a11a75920b0e8298865dc28c0eff6"},
+    {file = "SQLAlchemy-1.3.20-cp35-cp35m-win_amd64.whl", hash = "sha256:8dcbf377529a9af167cbfc5b8acec0fadd7c2357fc282a1494c222d3abfc9629"},
+    {file = "SQLAlchemy-1.3.20-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0157c269701d88f5faf1fa0e4560e4d814f210c01a5b55df3cab95e9346a8bcc"},
+    {file = "SQLAlchemy-1.3.20-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7cd40cb4bc50d9e87b3540b23df6e6b24821ba7e1f305c1492b0806c33dbdbec"},
+    {file = "SQLAlchemy-1.3.20-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:c092fe282de83d48e64d306b4bce03114859cdbfe19bf8a978a78a0d44ddadb1"},
+    {file = "SQLAlchemy-1.3.20-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:166917a729b9226decff29416f212c516227c2eb8a9c9f920d69ced24e30109f"},
+    {file = "SQLAlchemy-1.3.20-cp36-cp36m-win32.whl", hash = "sha256:632b32183c0cb0053194a4085c304bc2320e5299f77e3024556fa2aa395c2a8b"},
+    {file = "SQLAlchemy-1.3.20-cp36-cp36m-win_amd64.whl", hash = "sha256:bbc58fca72ce45a64bb02b87f73df58e29848b693869e58bd890b2ddbb42d83b"},
+    {file = "SQLAlchemy-1.3.20-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b15002b9788ffe84e42baffc334739d3b68008a973d65fad0a410ca5d0531980"},
+    {file = "SQLAlchemy-1.3.20-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:9e379674728f43a0cd95c423ac0e95262500f9bfd81d33b999daa8ea1756d162"},
+    {file = "SQLAlchemy-1.3.20-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2b5dafed97f778e9901b79cc01b88d39c605e0545b4541f2551a2fd785adc15b"},
+    {file = "SQLAlchemy-1.3.20-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:fcdb3755a7c355bc29df1b5e6fb8226d5c8b90551d202d69d0076a8a5649d68b"},
+    {file = "SQLAlchemy-1.3.20-cp37-cp37m-win32.whl", hash = "sha256:bca4d367a725694dae3dfdc86cf1d1622b9f414e70bd19651f5ac4fb3aa96d61"},
+    {file = "SQLAlchemy-1.3.20-cp37-cp37m-win_amd64.whl", hash = "sha256:f605f348f4e6a2ba00acb3399c71d213b92f27f2383fc4abebf7a37368c12142"},
+    {file = "SQLAlchemy-1.3.20-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:84f0ac4a09971536b38cc5d515d6add7926a7e13baa25135a1dbb6afa351a376"},
+    {file = "SQLAlchemy-1.3.20-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2909dffe5c9a615b7e6c92d1ac2d31e3026dc436440a4f750f4749d114d88ceb"},
+    {file = "SQLAlchemy-1.3.20-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:c3ab23ee9674336654bf9cac30eb75ac6acb9150dc4b1391bec533a7a4126471"},
+    {file = "SQLAlchemy-1.3.20-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:009e8388d4d551a2107632921320886650b46332f61dc935e70c8bcf37d8e0d6"},
+    {file = "SQLAlchemy-1.3.20-cp38-cp38-win32.whl", hash = "sha256:bf53d8dddfc3e53a5bda65f7f4aa40fae306843641e3e8e701c18a5609471edf"},
+    {file = "SQLAlchemy-1.3.20-cp38-cp38-win_amd64.whl", hash = "sha256:7c735c7a6db8ee9554a3935e741cf288f7dcbe8706320251eb38c412e6a4281d"},
+    {file = "SQLAlchemy-1.3.20-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:4bdbdb8ca577c6c366d15791747c1de6ab14529115a2eb52774240c412a7b403"},
+    {file = "SQLAlchemy-1.3.20-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:ce64a44c867d128ab8e675f587aae7f61bd2db836a3c4ba522d884cd7c298a77"},
+    {file = "SQLAlchemy-1.3.20-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:be41d5de7a8e241864189b7530ca4aaf56a5204332caa70555c2d96379e18079"},
+    {file = "SQLAlchemy-1.3.20-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1f5f369202912be72fdf9a8f25067a5ece31a2b38507bb869306f173336348da"},
+    {file = "SQLAlchemy-1.3.20-cp39-cp39-win32.whl", hash = "sha256:0cca1844ba870e81c03633a99aa3dc62256fb96323431a5dec7d4e503c26372d"},
+    {file = "SQLAlchemy-1.3.20-cp39-cp39-win_amd64.whl", hash = "sha256:d05cef4a164b44ffda58200efcb22355350979e000828479971ebca49b82ddb1"},
+    {file = "SQLAlchemy-1.3.20.tar.gz", hash = "sha256:d2f25c7f410338d31666d7ddedfa67570900e248b940d186b48461bd4e5569a1"},
 ]
 yarl = [
     {file = "yarl-1.5.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:db6db0f45d2c63ddb1a9d18d1b9b22f308e52c83638c26b422d520a815c4b3fb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [
 python = "^3.8"
 "discord.py" = "^1.5.1"
 psycopg2 = "^2.8.6"
+SQLAlchemy = "^1.3.20"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This PR adds support for using PostgresSQL to store player/server state.

It does so with the packages `psycopg2` and `sqlalchemy`, and connects to PostgresSQL database with tables for servers, players, items, and creatures. These tables should follow the format of corresponding DTOs already in master.

