### PR TITLE
Feature/leaderboard rebase

### DIFF
--- a/christmasbot/api/admin.py
+++ b/christmasbot/api/admin.py
@@ -3,7 +3,7 @@ from daos import get_dao
 from helpers.admin import format_bad_command_response, format_no_permissions_response, is_user_admin
 
 
-async def handle_enable_channel(message, tokens: list[str]):
+async def handle_enable_channel(message, tokens: list[str], bot):
   if len(tokens) > 1:
     response = format_bad_command_response(message.author)
   elif not is_user_admin(message.author, message.channel):
@@ -17,7 +17,7 @@ async def handle_enable_channel(message, tokens: list[str]):
   await message.channel.send(embed=response) 
   
 
-async def handle_disable_channel(message, tokens: list[str]):
+async def handle_disable_channel(message, tokens: list[str], bot):
   if len(tokens) > 1:
     response = format_bad_command_response(message.author)
   elif not is_user_admin(message.author, message.channel):
@@ -31,7 +31,7 @@ async def handle_disable_channel(message, tokens: list[str]):
   await message.channel.send(embed=response) 
 
 
-async def handle_change_despawn_time(message, tokens):
+async def handle_change_despawn_time(message, tokens, bot):
   if len(tokens) > 2:
     return BAD_COMMAND_MESSAGE
   new_despawn_time = -1
@@ -48,7 +48,7 @@ async def handle_change_despawn_time(message, tokens):
   await message.channel.send(response) 
 
 
-async def handle_change_spawn_rate(message, tokens: list[str]):
+async def handle_change_spawn_rate(message, tokens: list[str], bot):
   if len(tokens) > 2:
     return BAD_COMMAND_MESSAGE
   new_spawn_rate = -1
@@ -65,7 +65,7 @@ async def handle_change_spawn_rate(message, tokens: list[str]):
   await message.channel.send(response) 
 
 
-async def handle_refresh_role(message, tokens: list[str]):
+async def handle_refresh_role(message, tokens: list[str], bot):
   response = 'Refresh role placeholder'
   await message.channel.send(response) 
 

--- a/christmasbot/api/user.py
+++ b/christmasbot/api/user.py
@@ -1,13 +1,13 @@
 from constants.messages import HELP_MESSAGE
 from daos import get_dao
-from helpers.user import format_inventory
+from helpers.user import format_inventory, format_leaderboard
 
 
-async def handle_help(message, tokens: list[str]):
+async def handle_help(message, tokens: list[str], bot):
   await message.channel.send(embed=HELP_MESSAGE)
 
 
-async def handle_inventory(message, tokens: list[str]):
+async def handle_inventory(message, tokens: list[str], bot):
   dao = get_dao()
   server_id = message.guild.id
   author_profile = await dao.get_player(server_id, message.author.id)
@@ -18,12 +18,15 @@ async def handle_inventory(message, tokens: list[str]):
   await message.channel.send(embed=response)
 
 
-async def handle_leaderboard(message, tokens: list[str]):
-  response = 'leaderboard placeholder'
-  await message.channel.send(response) 
+async def handle_leaderboard(message, tokens: list[str], bot):
+  dao = get_dao()
+  leader_board = await dao.get_leaderboard(message.guild.id, None, None, bot)
+  print('leaderboard', leader_board)
+  response = format_leaderboard(leader_board)
+  await message.channel.send(embed=response)
 
 
-async def handle_tree(message, tokens: list[str]):
+async def handle_tree(message, tokens: list[str], bot):
   response = 'tree placeholder'
   await message.channel.send(response) 
 

--- a/christmasbot/constants/globals.py
+++ b/christmasbot/constants/globals.py
@@ -1,7 +1,9 @@
 from enum import IntEnum
 
 DISCORD_CLIENT_ID = '773308497538056222'
-DISCORD_TOKEN = ':)notthistime'
+DISCORD_TOKEN = 'rawrxDhaha'
+
+BLOB_URL = 'https://i.imgur.com/3SdgfhJ.png'
 
 DEFAULT_DESPAWN_TIME_SECONDS = 10
 DEFAULT_SPAWN_RATE_PERCENT = 100

--- a/christmasbot/constants/globals.py
+++ b/christmasbot/constants/globals.py
@@ -1,7 +1,9 @@
 from enum import IntEnum
 
 DISCORD_CLIENT_ID = '773308497538056222'
-DISCORD_TOKEN = ':)notthistime'
+DISCORD_TOKEN = 'd'
+
+BLOB_URL = 'https://i.imgur.com/3SdgfhJ.png'
 
 DEFAULT_DESPAWN_TIME_SECONDS = 10
 DEFAULT_SPAWN_RATE_PERCENT = 100

--- a/christmasbot/constants/messages.py
+++ b/christmasbot/constants/messages.py
@@ -30,13 +30,18 @@ NICE_INCORRECT = ('Wrong, as usual... It was a naughty {creature_name}. Oh no! {
       'thinks your mistake was an act of deception! In spite, {creature_pronoun} replaces '
       'your {replaced_item} with coal! Serves you right. ')
 
+UNKNOWN_SPAWN = ('A silhouette has appeared! From the\n'
+                 'looks of it, it seems quite {status}.\n'
+                 'Type *x!{status}* to identify the creature!')
+
 HELP_MESSAGE = discord.Embed(
   title='Christmas Command List',
-  description=('After watching the Halloween creatures from afar, the '
+  description=('After watching the Halloween creatures come from afar, the '
                 'Christmas creatures have decided to visit and leave presents '
                 'behind! Identify whether the creatures are nice or naughty '
                 'with the right command when they come and collect items to '
-                'become your server\'s Chamption of Christmas!'),
+                'become your server\'s Champion of Christmas! Collect all the '
+                'rare ornaments and something special might happen...'),
   color=discord.Colour(ChristmasColor.GOLD)
 ).set_author(
   name='Christmas Bot',

--- a/christmasbot/daos/memory_dao.py
+++ b/christmasbot/daos/memory_dao.py
@@ -1,5 +1,6 @@
 import random
 
+from operator import itemgetter
 from daos.abstract_dao import AbstractDao
 
 from dtos.creature import CreatureDto
@@ -16,8 +17,10 @@ class MemoryDao(AbstractDao):
         'https://i.imgur.com/MBmsrHG.png', 'nice', 
         ['gumdrop_ornament', 'iced_bowtie']),
       'naughty_gingy': CreatureDto('naughty_gingy', 'Naughty Gingy', 'he', 
-        'https://i.imgur.com/1CnajlU.png', 'naughty', ['dash_of_cinnamon', 'iced_bowtie'])
+        'https://i.imgur.com/1CnajlU.png', 'naughty',
+        ['dash_of_cinnamon', 'iced_bowtie'])
     }
+
     self.items: dict[str, ItemDto] = {
       'gumdrop_ornament': ItemDto('gumdrop_ornament', 'Gumdrop Ornament', 
         ItemRarity.RARE, 'https://i.imgur.com/1CnajlU.png'),
@@ -83,9 +86,13 @@ class MemoryDao(AbstractDao):
 
   # User Interactions
 
-  async def get_leaderboard(self, server_id: int, num_results, page):
-    self.create_server_entry_if_nonexistent(server_id)
-    pass
+  async def get_leaderboard(self, server, num_results, page, bot):
+    leader_board = {}
+    self.create_server_entry_if_nonexistent(server)
+    for player_id in self.server_players[server].keys():  # for player in dict
+      usr = await bot.fetch_user(player_id)
+      leader_board[usr.name] = len(self.server_players[server][player_id].inventory)
+    return leader_board
 
   async def get_player(self, server_id, player_id):
     self.create_server_entry_if_nonexistent(server_id)

--- a/christmasbot/daos/memory_dao.py
+++ b/christmasbot/daos/memory_dao.py
@@ -1,5 +1,6 @@
 import random
 
+from operator import itemgetter
 from daos.abstract_dao import AbstractDao
 
 from dtos.creature import CreatureDto
@@ -16,8 +17,10 @@ class MemoryDao(AbstractDao):
         'https://i.imgur.com/MBmsrHG.png', 'nice', 
         ['gumdrop_ornament', 'iced_bowtie']),
       'naughty_gingy': CreatureDto('naughty_gingy', 'Naughty Gingy', 'he', 
-        'https://i.imgur.com/1CnajlU.png', 'naughty', ['dash_of_cinnamon', 'iced_bowtie'])
+        'https://i.imgur.com/1CnajlU.png', 'naughty',
+        ['dash_of_cinnamon', 'iced_bowtie'])
     }
+
     self.items: dict[str, ItemDto] = {
       'gumdrop_ornament': ItemDto('gumdrop_ornament', 'Gumdrop Ornament', 
         'https://i.imgur.com/1CnajlU.png', ItemRarity.RARE),
@@ -83,9 +86,13 @@ class MemoryDao(AbstractDao):
 
   # User Interactions
 
-  async def get_leaderboard(self, server, num_results, page):
+  async def get_leaderboard(self, server, num_results, page, bot):
+    leader_board = {}
     self.create_server_entry_if_nonexistent(server)
-    pass
+    for player_id in self.server_players[server].keys():  # for player in dict
+      usr = await bot.fetch_user(player_id)
+      leader_board[usr.name] = len(self.server_players[server][player_id].inventory)
+    return leader_board
 
   async def get_player(self, server, player):
     self.create_server_entry_if_nonexistent(server)

--- a/christmasbot/helpers/spawn.py
+++ b/christmasbot/helpers/spawn.py
@@ -6,7 +6,7 @@ from discord.colour import Colour
 
 from constants.globals import ChristmasColor, get_ongoing_spawns
 from constants.messages import (CREATURE_IDENTIFIED_TITLE, CREATURE_MISIDENTIFIED_TITLE, CREATURE_SPAWN_TITLE, CREATURE_SPAWN_DESCRIPTION, CREATURE_TIMEOUT_DESCRIPTION, CREATURE_TIMEOUT_TITLE, 
-  NICE_CORRECT, NAUGHTY_CORRECT, NICE_INCORRECT, NAUGHTY_INCORRECT)
+  NICE_CORRECT, NAUGHTY_CORRECT, NICE_INCORRECT, NAUGHTY_INCORRECT, UNKNOWN_SPAWN)
 from daos import get_dao
 from daos.abstract_dao import AbstractDao
 from dtos.creature import CreatureDto
@@ -91,9 +91,7 @@ def remove_ongoing_spawn(server_id: int, channel_id: int):
   spawn_dict[server_id].pop(channel_id)
 
 
-def create_creature_message(creature: CreatureDto, item: ItemDto):
-    print('urls=', creature.img_url, ' ', item.img_url)
-    print('current dir=', getcwd())
+def create_creature_message(creature: CreatureDto):
     return discord.Embed(
       title=CREATURE_SPAWN_TITLE,
       description=format_spawn_description(creature),
@@ -102,14 +100,23 @@ def create_creature_message(creature: CreatureDto, item: ItemDto):
       url=creature.img_url
     )
 
+def create_blob_message(creature: CreatureDto):
+  return discord.Embed(
+    title='An unexpected guest!',
+    description=UNKNOWN_SPAWN.format(status=creature.status),
+    color=discord.Colour(ChristmasColor.WHITE),
+  ).set_image(
+    url='https://i.imgur.com/3SdgfhJ.png'
+  )
 
-def create_timeout_message(creature: CreatureDto):
+
+def create_timeout_message():
   return discord.Embed(
     title=CREATURE_TIMEOUT_TITLE,
     description=CREATURE_TIMEOUT_DESCRIPTION,
     color=discord.Colour(ChristmasColor.RED),
   ).set_image(
-    url=creature.img_url
+    url='https://i.imgur.com/3SdgfhJ.png'
   )
 
 def check_if_command_correct(user_message, creature: CreatureDto):

--- a/christmasbot/helpers/spawn.py
+++ b/christmasbot/helpers/spawn.py
@@ -6,7 +6,7 @@ from discord.colour import Colour
 
 from constants.globals import ChristmasColor, get_ongoing_spawns
 from constants.messages import (CREATURE_IDENTIFIED_TITLE, CREATURE_MISIDENTIFIED_TITLE, CREATURE_SPAWN_TITLE, CREATURE_SPAWN_DESCRIPTION, CREATURE_TIMEOUT_DESCRIPTION, CREATURE_TIMEOUT_TITLE, 
-  NICE_CORRECT, NAUGHTY_CORRECT, NICE_INCORRECT, NAUGHTY_INCORRECT)
+  NICE_CORRECT, NAUGHTY_CORRECT, NICE_INCORRECT, NAUGHTY_INCORRECT, UNKNOWN_SPAWN)
 from daos import get_dao
 from daos.abstract_dao import AbstractDao
 from dtos.creature import CreatureDto
@@ -22,12 +22,6 @@ def get_correct_command(creature: CreatureDto):
   if creature.status != 'nice' and creature.status != 'naughty':
     raise Exception('Creature was neither nice nor naughty! It was {}'.format(creature.status))
   return 'x!{}'.format(creature.status)
-
-#creature_name, creature_pronoun, item_pronoun, item_name, item_rarity, creature_name
-#creature_name, caps_creature_pronoun, creature_pronoun, item_pronoun, item_name, item_rarity
-#creature_name, caps_creature_pronoun, creature_pronoun, replaced_item
-#creature_name, caps_creature_pronoun, creature_pronoun, replaced_item
-
 
 def format_correct_naughty_response(creature: CreatureDto, item: ItemDto):
   return NAUGHTY_CORRECT.format(creature_name=creature.display_name,
@@ -101,14 +95,23 @@ def create_creature_message(creature: CreatureDto):
       url=creature.img_url
     )
 
+def create_blob_message(creature: CreatureDto):
+  return discord.Embed(
+    title='An unexpected guest!',
+    description=UNKNOWN_SPAWN.format(status=creature.status),
+    color=discord.Colour(ChristmasColor.WHITE),
+  ).set_image(
+    url='https://i.imgur.com/3SdgfhJ.png'
+  )
 
-def create_timeout_message(creature: CreatureDto):
+
+def create_timeout_message():
   return discord.Embed(
     title=CREATURE_TIMEOUT_TITLE,
     description=CREATURE_TIMEOUT_DESCRIPTION,
     color=discord.Colour(ChristmasColor.RED),
   ).set_image(
-    url=creature.img_url
+    url='https://i.imgur.com/3SdgfhJ.png'
   )
 
 def check_if_command_correct(user_message, creature: CreatureDto):

--- a/christmasbot/helpers/user.py
+++ b/christmasbot/helpers/user.py
@@ -17,3 +17,26 @@ def format_inventory(inventory: list[ItemDto]):
   return discord.Embed(title='Wow! Look at all your items:',
                        description=formatted_string,
                        color=discord.Colour(ChristmasColor.GOLD))
+
+def format_leaderboard(leader_board: dict):
+    formatted_string = '```\nRank | Items | User\n======================================\n'
+    leaderboard_sorted_keys = sorted(leader_board, key=leader_board.get, reverse=True)
+    if len(leader_board) == 0:
+        formatted_string = '```yaml\nWait... No one has got any items? Are you even trying? ' \
+                           'Why\'d you even add me to this server?? Does my time and memory ' \
+                           'mean nothing to you??? Well, thanks for nothing...'
+    else:
+        for rank, player in enumerate(leaderboard_sorted_keys):
+                add_to_formatted_string = "{0:4.0f} | {1:5.0f} | {2}\n".format(rank+1, leader_board[player], player)
+                formatted_string = formatted_string + add_to_formatted_string
+                if rank >= 5:
+                    break
+        formatted_string = formatted_string + '\n``` \n ```yaml\n' \
+                                              'Not bad for a bunch of discount Santas! ' \
+                                              'As for the rest of you... ' \
+                                              'Well, cheer up, I\'m sure there ' \
+                                              'is something you\'re good at!'
+
+    return discord.Embed(title='Our top 5 gift hustlers are...',
+                        description=formatted_string + '```\n',
+                        color=discord.Colour(ChristmasColor.GOLD))

--- a/christmasbot/main.py
+++ b/christmasbot/main.py
@@ -2,13 +2,20 @@ import asyncio
 import random
 
 import discord
+import psycopg2
 
 from api.admin import ADMIN_COMMAND_LIST
 from api.user import USER_COMMAND_LIST
-from constants.globals import DISCORD_TOKEN
+from constants.globals import DISCORD_TOKEN, BLOB_URL
 from daos import get_dao
 from helpers.spawn import (check_if_command_correct, create_bot_response, create_timeout_message, get_random_creature, get_random_item,
-  add_ongoing_spawn, has_ongoing_spawn, remove_ongoing_spawn, create_creature_message)
+  add_ongoing_spawn, has_ongoing_spawn, remove_ongoing_spawn, create_creature_message, create_blob_message)
+
+#conn = psycopg2.connect(
+    #host="christmasbot-db.comnjzshch4a.us-west-1.rds.amazonaws.com",
+    #database="christmasbot_beta",
+    #user="kashyap",
+   # password="santa")
 
 def load_command_list():
   command_list = {}
@@ -39,8 +46,7 @@ class ChristmasBot(discord.Client):
     response = 'Placeholder message - you shouldn\'t be seeing this'
     if command in self.command_list.keys():
       print('Invoking command {}'.format(command))
-      await self.command_list[command](message, tokens)
-      await message.delete(delay=10)
+      await self.command_list[command](message, tokens, self)
     elif command in ['x!nice', 'x!naughty'] and not has_ongoing_spawn(server_id, channel_id):
       # prevents max from spamming x!nice/naughty
       return
@@ -59,7 +65,7 @@ class ChristmasBot(discord.Client):
           item = await get_random_item(creature)
           # lock spawn so 2 spawns don't happen at the same time
           add_ongoing_spawn(server_id, channel_id, creature)
-          bot_message = await message.channel.send(embed=create_creature_message(creature, item))
+          bot_message = await message.channel.send(embed=create_blob_message(creature))
 
           def message_is_nice_or_naughty(message):
             return (message.guild.id == server_id and message.channel.id == channel_id
@@ -76,7 +82,7 @@ class ChristmasBot(discord.Client):
             
             await reply.delete(delay=5)
           except asyncio.TimeoutError:
-            bot_response = create_timeout_message(creature)
+            bot_response = create_timeout_message()
           finally:
             remove_ongoing_spawn(server_id, channel_id)
             await bot_message.edit(embed=bot_response)

--- a/christmasbot/main.py
+++ b/christmasbot/main.py
@@ -5,10 +5,10 @@ import discord
 
 from api.admin import ADMIN_COMMAND_LIST
 from api.user import USER_COMMAND_LIST
-from constants.globals import DISCORD_TOKEN
+from constants.globals import DISCORD_TOKEN, BLOB_URL
 from daos import get_dao
 from helpers.spawn import (check_if_command_correct, create_bot_response, create_timeout_message, get_random_creature, get_random_item,
-  add_ongoing_spawn, has_ongoing_spawn, remove_ongoing_spawn, create_creature_message)
+  add_ongoing_spawn, has_ongoing_spawn, remove_ongoing_spawn, create_creature_message, create_blob_message)
 
 def load_command_list():
   command_list = {}
@@ -39,8 +39,7 @@ class ChristmasBot(discord.Client):
     response = 'Placeholder message - you shouldn\'t be seeing this'
     if command in self.command_list.keys():
       print('Invoking command {}'.format(command))
-      await self.command_list[command](message, tokens)
-      await message.delete(delay=10)
+      await self.command_list[command](message, tokens, self)
     elif command in ['x!nice', 'x!naughty'] and not has_ongoing_spawn(server_id, channel_id):
       # prevents max from spamming x!nice/naughty
       return
@@ -58,7 +57,7 @@ class ChristmasBot(discord.Client):
           creature = await get_random_creature()
           # lock spawn so 2 spawns don't happen at the same time
           add_ongoing_spawn(server_id, channel_id, creature)
-          bot_message = await message.channel.send(embed=create_creature_message(creature))
+          bot_message = await message.channel.send(embed=create_blob_message(creature))
 
           def message_is_nice_or_naughty(message):
             return (message.guild.id == server_id and message.channel.id == channel_id
@@ -75,7 +74,7 @@ class ChristmasBot(discord.Client):
             
             await reply.delete(delay=5)
           except asyncio.TimeoutError:
-            bot_response = create_timeout_message(creature)
+            bot_response = create_timeout_message()
           finally:
             remove_ongoing_spawn(server_id, channel_id)
             await bot_message.edit(embed=bot_response)


### PR DESCRIPTION
This PR adds functionality to 'x!leaderboard', as well as an initial unknown creature spawn. 

The significant change is now 'bot' is as an argument to every API function (though it is only used in calling leaderboard). This is to access bot.fetch_user for player names. 

Initial creature spawns now show up as a blob, and are revealed when the correct command is called.  